### PR TITLE
New SSH Status Color

### DIFF
--- a/src/assets/less/compass/variables/_palette.less
+++ b/src/assets/less/compass/variables/_palette.less
@@ -10,17 +10,17 @@
 @green4: #a6c88e;
 @green5: #c4dbb3;
 
-@gray0: #313030;
-@gray1: #494747;
-@gray2: #615f5f;
-@gray3: #807f7f;
-@gray4: #a09f9e;
-@gray5: #bfbfbe;
+@gray0: #061621; // black
+@gray1: #21313C; // gray dark3
+@gray2: #3D4F58; // gray dark2
+@gray3: #3D4F58; // TODO: deprecate
+@gray4: #5D6C74; // gray dark1
+@gray5: #88989A; // gray base
 
 /* UI Grays */
-@gray6: #dee0e3;
-@gray7: #ebebed;
-@gray8: #f5f6f7;
+@gray6: #B8C3C2; // gray light1
+@gray7: #E7EEEC; // gray light2
+@gray8: #F9FBFA; // gray light3
 
 @slate0: #42494f;
 @slate1: #4c5259;

--- a/src/components/ssh-tunnel-status/ssh-tunnel-status.less
+++ b/src/components/ssh-tunnel-status/ssh-tunnel-status.less
@@ -1,12 +1,11 @@
 @import (reference) "~less/compass/_theme.less";
-@compass-sidebar-base-background-color: #42494f;
 
 .ssh-tunnel-status {
-  background-color: @compass-sidebar-base-background-color;
+  background: inherit;
   display: flex;
   flex-direction: column;
   font-family: "Akzidenz", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 14px;
+  font-size: 12px;
   padding: 6px 12px 6px 12px;
 
   &-label {
@@ -16,7 +15,7 @@
   }
 
   &-string {
-    color: #AAAAAA;
+    color: @gray5;
     text-overflow: ellipsis;
   }
 }

--- a/src/components/ssh-tunnel-status/ssh-tunnel-status.less
+++ b/src/components/ssh-tunnel-status/ssh-tunnel-status.less
@@ -5,17 +5,18 @@
   display: flex;
   flex-direction: column;
   font-family: "Akzidenz", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  font-size: 12px;
-  padding: 6px 12px 6px 12px;
+  padding: 6px 24px 6px 24px;
 
   &-label {
     text-transform: uppercase;
-    color: @pw;
+    color: @gray5;
     font-weight: bold;
+    font-size: 11px;
   }
 
   &-string {
-    color: @gray5;
+    color: @pw;
     text-overflow: ellipsis;
+    font-size: 14px;
   }
 }


### PR DESCRIPTION
<img width="362" alt="Screen Shot 2019-07-29 at 11 27 24 AM" src="https://user-images.githubusercontent.com/7270285/62060820-dfb71e00-b1f3-11e9-9068-7f8f809a5d10.png">

* Removed background color so it inherits the parent background
* Reduced label font-size to 11px
* Swapped the label colors and text sizes